### PR TITLE
use iss_updated_date for issue last action date information

### DIFF
--- a/src/Event/Subscriber/EventumUnfurler.php
+++ b/src/Event/Subscriber/EventumUnfurler.php
@@ -139,17 +139,14 @@ class EventumUnfurler implements EventSubscriberInterface
     }
 
     /**
-     * Get last update whether internal or public last action date
+     * Get issue last update in local timezone
      *
      * @param array $issue
      * @return DateTime last action date in specified timeZone
      */
     private function getLastUpdate(array $issue)
     {
-        $ts1 = new DateTime($issue['iss_last_internal_action_date'], $this->utc);
-        $ts2 = new DateTime($issue['iss_last_public_action_date'], $this->utc);
-
-        $lastUpdated = $ts1 > $ts2 ? $ts1 : $ts2;
+        $lastUpdated = new DateTime($issue['iss_updated_date'], $this->utc);
         $lastUpdated->setTimezone($this->timeZone);
 
         return $lastUpdated;


### PR DESCRIPTION
in some scenarios the internal action date is null, and previous logic sorted that as newer, thus the result was to show current date rather actual last action date.

```
15:23:36 mysql{1}> select iss_last_internal_action_date, iss_last_public_action_date, iss_updated_date from issue where iss_id=102631\G
*************************** 1. row ***************************
iss_last_internal_action_date: NULL
  iss_last_public_action_date: 2018-08-13 12:22:33
             iss_updated_date: 2018-08-13 12:22:33
1 row in set (0.00 sec)
```

cc @raul72 